### PR TITLE
fix: drop literal quotes from flyway_extra_params default

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -41,7 +41,7 @@ inputs:
   flyway_extra_params:
     description: Add extra params to Flyway command. By defaults, it adds -outOfOrder=true
     required: false
-    default: '-outOfOrder="true" -ignoreMigrationPatterns="*:missing"'
+    default: '-outOfOrder=true -ignoreMigrationPatterns=*:missing'
   flyway_command:
     description: 'Command to run. Ej: migrate, repair'
     required: false


### PR DESCRIPTION
## Summary

- Drops literal double quotes from the `flyway_extra_params` default value so flyway doesn't receive them as part of the arg.

## Context

The `Make migrations` step runs:

\`\`\`bash
flyway \$FLYWAY_COMMAND -url=... \$FLYWAY_EXTRA_PARAMS ...
\`\`\`

`\$FLYWAY_EXTRA_PARAMS` is word-split by bash but **not** quote-processed (quote removal only happens in the initial parse, not on re-expansion). The previous default `-outOfOrder="true" -ignoreMigrationPatterns="*:missing"` therefore reached flyway as the literal argument `-outOfOrder="true"` (with the `"` still attached), and flyway rejected it:

\`\`\`
ERROR: Invalid value for flyway.outOfOrder (should be either true or false): "true"
\`\`\`

Real-world hit: [meetlara/chat-service#1614 run 24283368219](https://github.com/meetlara/chat-service/actions/runs/24283368219/job/70908636352).

## Fix

Drop the quotes in the default:

\`\`\`diff
- default: '-outOfOrder="true" -ignoreMigrationPatterns="*:missing"'
+ default: '-outOfOrder=true -ignoreMigrationPatterns=*:missing'
\`\`\`

Paired with meetlara/stg-migrate-on-comment#1 which fixes the same hardcoded override there.

## Test plan

- [ ] Trigger a \`migrate db\` comment on an open PR in any consumer (chat-service, dashboard-service, etc.) after this lands and confirm the step completes.
- [ ] Verify no new globbing surprises — the \`*:missing\` ignore pattern is still interpreted by flyway because nothing in CWD should match \`*:missing\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected default Flyway CLI parameter formatting to ensure proper flag parsing by removing unnecessary quotes from parameter values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->